### PR TITLE
Add iproute2 package

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -38,6 +38,7 @@ git-core
 # gnupg-curl ?
 ghostscript-fonts
 ImageMagick
+iproute2
 # iputils-arping ? iputils
 # krb5-user ?
 jq


### PR DESCRIPTION
CATS requires the `ip` command:
https://github.com/cloudfoundry/cf-acceptance-tests/blob/228ae44d012a595eaa48f4d9049b427aa15637c6/assets/catnip/linux/linux.go#L22