### PR TITLE
Add `fuse-devel` for CATs

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -33,6 +33,8 @@ dmidecode
 flex
 fontconfig
 # fuse-emulator-utils ?
+fuse-devel
+# fuse-devel is needed by the fuse-mount test app in the CATs.
 gdb
 git-core
 # gnupg-curl ?


### PR DESCRIPTION
Details in https://trello.com/c/MWgYpR8T/523-cats-fuse-endpoint

See also https://github.com/SUSE/cf-suse-stacks/pull/2 for analogous change for a related ticket.
